### PR TITLE
config key for custom mongo image

### DIFF
--- a/pkg/storage/plugins/mongodb_docker/plugin.go
+++ b/pkg/storage/plugins/mongodb_docker/plugin.go
@@ -13,10 +13,13 @@ import (
 // PluginKey is the identifier of the internal mongodb run in docker plugin.
 const PluginKey = plugins.PluginInterface + ".porter.mongodb-docker"
 
+const MongoImage = "mongo:4.0-xenial"
+
 // PluginConfig supported by the mongodb-docker plugin as defined in porter.yaml
 type PluginConfig struct {
 	Port     string `mapstructure:"port,omitempty"`
 	Database string `mapstructure:"database,omitempty"`
+	Image    string `mapstructure:"image,omitempty"`
 
 	// Timeout in seconds
 	Timeout int `mapstructure:"timeout,omitempty"`
@@ -27,6 +30,7 @@ func NewPlugin(c *portercontext.Context, rawCfg interface{}) (plugin.Plugin, err
 	cfg := PluginConfig{
 		Port:     "27018",
 		Database: "porter",
+		Image:    MongoImage,
 		Timeout:  10,
 	}
 	if err := mapstructure.Decode(rawCfg, &cfg); err != nil {

--- a/pkg/storage/plugins/mongodb_docker/store.go
+++ b/pkg/storage/plugins/mongodb_docker/store.go
@@ -54,7 +54,7 @@ func (s *Store) Connect(ctx context.Context) error {
 	container := "porter-mongodb-docker-plugin"
 	dataVol := container + "-data"
 
-	conn, err := EnsureMongoIsRunning(ctx, s.context, container, s.config.Port, dataVol, s.config.Database, s.config.Timeout)
+	conn, err := EnsureMongoIsRunning(ctx, s.context, container, s.config.Image, s.config.Port, dataVol, s.config.Database, s.config.Timeout)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (s *Store) Update(ctx context.Context, opts plugins.UpdateOptions) error {
 	return s.Store.Update(ctx, opts)
 }
 
-func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, container string, port string, dataVol string, dbName string, timeoutSeconds int) (*mongodb.Store, error) {
+func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, container string, image string, port string, dataVol string, dbName string, timeoutSeconds int) (*mongodb.Store, error) {
 	ctx, span := tracing.StartSpan(ctx)
 	defer span.EndSpan()
 
@@ -164,7 +164,8 @@ func EnsureMongoIsRunning(ctx context.Context, c *portercontext.Context, contain
 
 	// TODO(carolynvs): run this using the docker library
 	startMongo := func() error {
-		mongoImg := "mongo:4.0-xenial"
+		//ab mongoImg := "mongo:4.0-xenial"
+		mongoImg := image
 		span.Debugf("pulling %s", mongoImg)
 
 		err := exec.Command("docker", "pull", mongoImg).Run()

--- a/pkg/storage/plugins/testplugin/plugin.go
+++ b/pkg/storage/plugins/testplugin/plugin.go
@@ -70,7 +70,7 @@ func (s *TestStoragePlugin) useDevDatabase(ctx context.Context) error {
 }
 
 func (s *TestStoragePlugin) runTestDatabase(ctx context.Context) error {
-	testMongo, err := mongodb_docker.EnsureMongoIsRunning(ctx, s.tc.Context, "porter-test-mongodb-plugin", "27017", "", s.database, 10)
+	testMongo, err := mongodb_docker.EnsureMongoIsRunning(ctx, s.tc.Context, "porter-test-mongodb-plugin", "mongo:4.0-xenial", "27017", "", s.database, 10)
 	if err != nil {
 		return err
 	}

--- a/tests/tester/main.go
+++ b/tests/tester/main.go
@@ -88,6 +88,7 @@ func (t Tester) startMongo(ctx context.Context) error {
 	conn, err := mongodb_docker.EnsureMongoIsRunning(ctx,
 		t.TestContext.Context,
 		"porter-smoke-test-mongodb-plugin",
+		"mongo:4.0-xenial",
 		"27017",
 		"",
 		t.dbName,


### PR DESCRIPTION
# What does this change
Add key "image" into "storage.config" in config file which describes way to actual mongo image.
I.E.

```
default-storage: "new"
storage:
  name: "new"
  plugin: "mongodb-docker"
  config:
    image: "repo/project/mongo:tag"
```

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you change porter.yaml or a storage document record? Update the corresponding schema file.
- [ ] If this is your first pull request, please add your name to the bottom of our [Contributors][contributors] list. Thank you for making Porter better! 🙇‍♀️

# Reviewer Checklist
* Comment with /azp run test-porter-release if a magefile or build script was modified
* Comment with /azp run porter-integration if it's a non-trivial PR

[contributors]: https://getporter.org/src/CONTRIBUTORS.md